### PR TITLE
インストール時にURLからhtmlを無くす手順のページを追加

### DIFF
--- a/remove_html.md
+++ b/remove_html.md
@@ -1,0 +1,120 @@
+---
+layout: default
+title: インストール時にURLからhtmlを無くす
+---
+
+---
+
+# インストール時にURLからhtmlを無くす手順
+
+一部のレンタルサーバーなどDocumentRootを変更できない環境でも、インストール時に下記の手順を行うことで、URLからhtmlを無くした状態でインストールが可能です。
+  
+例) `https://www.sampleshop.com/html/` → `https://www.sampleshop.com/`
+
+## 対応バージョン
+EC-CUBE 3.0.11 以降
+
+## ご注意
+下記の手順を行うことで、通常のEC-CUBEとは異なるファイル構成になります。  
+そのため、一部のプラグインなどが正常に動作しない可能性があることをご理解ください。  
+  
+また、この方法でのインストールを行う前に、まずはDocumentRootの変更などサーバー設定での対応をご検討ください。  
+
+## 作業手順
+__インストールを行う前__ に、以下作業を実施します。
+1. ファイル配置場所の変更
+2. .htaccess / web.config の置き換え
+3. index.php / index_dev.php / install.php の変更
+4. autoload.php の変更
+5. EC-CUBEのインストール
+
+### 1. ファイル配置場所の変更
+以下の6つのファイルを、htmlフォルダの中から一階層上に移動します。(コピーではありません)
+```
+[root]
+  ├──[html]
+  │   ├── index.php
+  │   ├── index_dev.php
+  │   ├── install.php
+  │   ├── robots.txt
+  │   ├── .htaccess
+  │   └── web.config
+  │
+```
+↓  
+```
+[root]
+  ├──[html]
+  │
+  ├── index.php
+  ├── index_dev.php
+  ├── install.php
+  ├── robots.txt
+  ├── .htaccess
+  ├── web.config
+```
+
+### 2. .htaccess / web.config の置き換え
+手順1でコピーしてきた`.hraccess``web.config`を削除します。
+```
+[root]
+  │
+  ├── .htaccess   ← 削除
+  ├── web.config  ← 削除
+  ├── .htaccess.sample
+  ├── web.config.sample
+```
+
+`.hraccess.sample``web.config.sample`をそれぞれ`.hraccess``web.config`にリネームします。
+```
+[root]
+  │
+  ├── .htaccess.sample
+  ├── web.config.sample
+```
+↓
+```
+[root]
+  │
+  ├── .htaccess
+  ├── web.config
+```
+
+### 3. index.php / index_dev.php / install.php の変更
+それぞれのファイルで、以下のようにコメントアウトする行を変更します。
+
+- index.php
+- index_dev.php
+- install.php
+
+```
+//[INFO]index.php,install.phpをEC-CUBEルート直下に移動させる場合は、コメントアウトしている行に置き換える
+require __DIR__.'/../autoload.php';
+//require __DIR__.'/autoload.php';
+```
+↓  
+```
+//[INFO]index.php,install.phpをEC-CUBEルート直下に移動させる場合は、コメントアウトしている行に置き換える
+//require __DIR__.'/../autoload.php';
+require __DIR__.'/autoload.php';
+```
+
+### 4. autoload.php の変更
+autoload.php で、以下のようにコメントアウトする行を変更します。
+```
+//[INFO]index.php,install.phpをEC-CUBEルート直下に移動させる場合は、コメントアウトしている行に置き換える
+define("RELATIVE_PUBLIC_DIR_PATH", '');
+//define("RELATIVE_PUBLIC_DIR_PATH", '/html');
+```
+↓
+```
+//[INFO]index.php,install.phpをEC-CUBEルート直下に移動させる場合は、コメントアウトしている行に置き換える
+//define("RELATIVE_PUBLIC_DIR_PATH", '');
+define("RELATIVE_PUBLIC_DIR_PATH", '/html');
+```
+
+### 5. EC-CUBEのインストール
+EC-CUBEを配置したサイトにアクセスするとインストール画面が表示されます。  
+画面の指示に従ってインストールを進めてください。  
+  
+※インストール画面で大きなレイアウト崩れが発生している場合は、正常にインストールできない可能性があります。 再度、上記手順をご確認ください。

--- a/remove_html.md
+++ b/remove_html.md
@@ -9,7 +9,7 @@ title: インストール時にURLからhtmlを無くす
 
 一部のレンタルサーバーなどDocumentRootを変更できない環境でも、インストール時に下記の手順を行うことで、URLからhtmlを無くした状態でインストールが可能です。
   
-例) `https://www.sampleshop.com/html/` → `https://www.sampleshop.com/`
+例) `https://www.example.com/html/` → `https://www.example.com/`
 
 ## 対応バージョン
 EC-CUBE 3.0.11 以降
@@ -55,7 +55,7 @@ __インストールを行う前__ に、以下作業を実施します。
 ```
 
 ### 2. .htaccess / web.config の置き換え
-手順1でコピーしてきた`.hraccess``web.config`を削除します。
+手順1で移動してきた`.htaccess``web.config`を削除します。
 ```
 [root]
   │
@@ -65,7 +65,7 @@ __インストールを行う前__ に、以下作業を実施します。
   ├── web.config.sample
 ```
 
-`.hraccess.sample``web.config.sample`をそれぞれ`.hraccess``web.config`にリネームします。
+`.htaccess.sample``web.config.sample`をそれぞれ`.htaccess``web.config`にリネームします。
 ```
 [root]
   │


### PR DESCRIPTION
インストール時にURLからhtmlを無くす手順のページを追加しました。
3.0.11リリースのタイミングで、目次からリンクします。