### PR TITLE
git clone実行後、リポジトリに対するgitコマンドを実行するための手順を追加

### DIFF
--- a/pages/collaboration/collaboration_githubflow.md
+++ b/pages/collaboration/collaboration_githubflow.md
@@ -44,7 +44,7 @@ folder: collaboration
 $ git clone https://github.com/[GitHubUser(ご自身のアカウント)]/ec-cube.git
 ```
 
-- ブランチの状態を確認してみます。  
+ブランチの状態を確認してみます。  
 ※gitコマンドを実行するために、事前にcloneしたリポジトリのディレクトリ直下に移動してください。  
 例：`cd ec-cube`
 

--- a/pages/collaboration/collaboration_githubflow.md
+++ b/pages/collaboration/collaboration_githubflow.md
@@ -44,8 +44,8 @@ folder: collaboration
 $ git clone https://github.com/[GitHubUser(ご自身のアカウント)]/ec-cube.git
 ```
 
-- ブランチの状態を確認してみます。
-※gitコマンドを実行するために、事前にcloneしたリポジトリのディレクトリ直下に移動してください。
+- ブランチの状態を確認してみます。  
+※gitコマンドを実行するために、事前にcloneしたリポジトリのディレクトリ直下に移動してください。  
 例：`cd ec-cube`
 
 ```


### PR DESCRIPTION
`cd ec-cube` を行っておらず、困っている方がいると伺ったので追記しました。