### PR TITLE
マイグレーションでのテーブル作成部分の修正

### DIFF
--- a/pages/plugin/bp/plugin_bp_migration.md
+++ b/pages/plugin/bp/plugin_bp_migration.md
@@ -69,7 +69,7 @@ class VersionYYYYMMDDHHMMSS extends AbstractMigration
         if ($schema->hasTable(self::NAME)) {
             return true;
         }
-        $table = $schema->getTable(self::NAME);
+        $table = $schema->createTable(self::NAME);
         $table->addColumn('nickname', 'string', array('notnull' => true, 'length' => 50));
         $table->changeColumn('email', 'string', array('notnull' => false, 'length' => 250));
     }


### PR DESCRIPTION
`$schema->hasTable(self::NAME)` が `false` となる場合の処理なので `$schema->getTable(self::NAME)` はエラーとなるはずです。