### PR TITLE
wikiのコピーライトポリシーにリンクするようにした。

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ EC-CUBE 4 の仕様や手順、開発Tipsに関するドキュメントを掲載
 ### 開発協力に関して
 
 コードの提供・追加、修正・変更その他「EC-CUBE」への開発の御協力（Issue投稿、PullRequest投稿など、GitHub上での活動）を行っていただく場合には、
-[EC-CUBEのコピーライトポリシー](https://github.com/EC-CUBE/ec-cube/blob/50de4ac511ab5a5577c046b61754d98be96aa328/LICENSE.txt)をご理解いただき、ご了承いただく必要がございます。
+[EC-CUBEのコピーライトポリシー](https://github.com/EC-CUBE/ec-cube/wiki/EC-CUBE%E3%81%AE%E3%82%B3%E3%83%94%E3%83%BC%E3%83%A9%E3%82%A4%E3%83%88%E3%83%9D%E3%83%AA%E3%82%B7%E3%83%BC)をご理解いただき、ご了承いただく必要がございます。
 PullRequestを送信する際は、EC-CUBEのコピーライトポリシーに同意したものとみなします。
 
 ## 本ドキュメントサイトの構成について


### PR DESCRIPTION
READMEから古いLICENSE.txtにリンクをしているところを、wikiのコピーライトポリシーにリンクするように修正しました。