### PR TITLE
文言統一、コマンドのシンタックスハイライト設定など。

### DIFF
--- a/pages/quickstart/install.md
+++ b/pages/quickstart/install.md
@@ -30,7 +30,7 @@ FTP/SSHを使用し、ファイルをサーバへアップロードしてくだ�
 - 3系の場合: `http://example.com/{EC-CUBEをアップロードしたディレクトリ}/html`
 - 4系の場合: `http://example.com/{EC-CUBEをアップロードしたディレクトリ}`
 
-webインストーラが表示されますので必要な情報を入力してインストールします。
+Webインストーラが表示されますので、指示にしたがってインストールしてください。
 
 ### コマンドラインからインストールする
 
@@ -38,30 +38,31 @@ webインストーラが表示されますので必要な情報を入力して�
 
 前提として、 [Composer のインストール](https://getcomposer.org/download/){:target="_blank"} が必要です。
 
-```
+```shell
 php composer.phar create-project ec-cube/ec-cube ec-cube "4.0.x-dev" --keep-vcs
 ```
 
-上記の例では、データベースに SQLite3 が選択されます。
++ 初期状態では SQLite3 を使用します
 
 ec-cube ディレクトリに移動し、 `bin/console server:run` コマンドを実行すると、ビルトインウェブサーバが起動します。
 
-```
+```shell
 cd ec-cube
 bin/console server:run
 ```
 
-[http://127.0.0.1:8000/admin](http://127.0.0.1:8000/admin) にアクセスし、 EC-CUBE の管理ログイン画面が表示されればインストール成功です。以下の ID/Password にてログインしてください。
+[http://127.0.0.1:8000/admin](http://127.0.0.1:8000/admin) にアクセスし、 EC-CUBE の管理ログイン画面が表示されればインストール成功です。  
+以下の ID/Password にてログインしてください。
 
 `ID: admin PW: password`
 
-*終了する場合は Ctrl+C を押してください*
+*ビルトインウェブサーバを終了する場合は `Ctrl+C` を押してください*
 
 #### データベースの種類を変更したい場合
 
 インストール後、 `bin/console eccube:install` コマンドを実行し、 `Database Url` を以下のように設定してください。
 
-```
+```shell
 ## for MySQL
 mysql://<user>:<password>@<host>/<database name>
 
@@ -74,7 +75,7 @@ postgres://<user>:<password>@<host>/<database name>
 `bin/console eccube:install` コマンドは使用できません。
 代替として、以下のコマンド使用して下さい。
 
-```
+```shell
 # (optional) データベース削除
 bin/console doctrine:database:drop --force
 # データベース作成
@@ -88,19 +89,19 @@ bin/console eccube:fixtures:load
 ```
 
 - *`bin/console eccube:install` コマンドでは、これらのコマンドを内部的に実行しています。*
-- Symfony と Windows 環境の相性があまり良くないため、動作が大変遅くなる可能性があります。 [Dockerを使用したインストール](http://doc4.ec-cube.net/quickstart_install#Docker%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%9F%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB) をおすすめします。
+- Symfony と Windows 環境の相性があまり良くないため、動作が大変遅くなる可能性があります。 [Dockerを使用したインストール](http://doc4.ec-cube.net/quickstart_install#docker%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%9F%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB) をおすすめします。
 
 ### Webインストーラでインストールする
 
 前提として、 [Composer のインストール](https://getcomposer.org/download/){:target="_blank"} が必要です。
 
-```
+```shell
 php composer.phar create-project --no-scripts ec-cube/ec-cube ec-cube "4.0.x-dev" --keep-vcs
 ```
 
 ec-cube ディレクトリに移動し、 `bin/console server:run` コマンドを実行すると、ビルトインウェブサーバが起動します。
 
-```
+```shell
 cd ec-cube
 bin/console server:run
 ```
@@ -109,7 +110,7 @@ bin/console server:run
 
 ### Dockerを使用してインストールする
 
-前提として、 [Docker Desktop のインストール](https://hub.docker.com) が必要です。
+前提として、 [Docker Desktop のインストール](https://hub.docker.com){:target="_blank"} が必要です。
 
 + 初期状態では SQLite3 を使用します
 + コンテナ上のファイルを使用しても、VOLUME をマウントしても使用可能です
@@ -117,12 +118,19 @@ bin/console server:run
 ```shell
 cd path/to/ec-cube
 docker build -t eccube4-php-apache .
+
 ## コンテナ上のファイルを使用する場合
 docker run --name ec-cube -p "8080:80" -p "4430:443" eccube4-php-apache
 
 ## ローカルディレクトリをマウントする場合
 # var 以下をマウントすると強烈に遅くなるため、 src, html, app 以下のみをマウントする
 docker run --name ec-cube -p "8080:80" -p "4430:443"  -v "$PWD/html:/var/www/html/html:cached" -v "$PWD/src:/var/www/html/src:cached" -v "$PWD/app:/var/www/html/app:cached" eccube4-php-apache
+```
+
+**2回目以降の起動時は、以下のコマンドを実行します。**
+
+```shell
+docker start --attach ec-cube
 ```
 
 #### 設定ファイルを編集する場合
@@ -146,7 +154,7 @@ docker run --name ec-cube -p "8080:80" -p "4430:443"  --link mailcatcher:mailcat
 
 #### PostgreSQL を使用する場合
 
-```
+```shell
 ## .env にて DATABASE_URL=pgsql://postgres:password@db/cube4_dev としておく
 docker run --name container_postgres -e POSTGRES_PASSWORD=password  -p 5432:5432 -d postgres
 docker run --name ec-cube -p "8080:80" -p "4430:443" --link container_postgres:db eccube4-php-apache
@@ -154,7 +162,7 @@ docker run --name ec-cube -p "8080:80" -p "4430:443" --link container_postgres:d
 
 #### MySQL を使用する場合
 
-```
+```shell
 ## .env にて DATABASE_URL=mysql://root:password@db/cube4_dev としておく
 docker run --name container_mysql -e MYSQL_ROOT_PASSWORD=password  -d -p 3306:3306 mysql:5.7
 docker run --name ec-cube -p "8080:80" -p "4430:443" --link container_mysql:db eccube4-php-apache
@@ -190,7 +198,7 @@ SetEnv ECCUBE_COOKIE_PATH /
 ApplicationHost.config の environmentVariables セクションに設定します。このファイルは `C:\Windows\System32\Inetsrv\Config` にあります。
 PHP実行ファイルのパスは適宜変更してください。
 
-```
+```xml
 <fastCgi>
     <application fullPath="C:\Program Files\PHP\v7.2\php-cgi.exe" activityTimeout="600" requestTimeout="600" instanceMaxRequests="10000">
         <environmentVariables>


### PR DESCRIPTION
* 4つのインストール方式それぞれについて、ほぼ同じ手順が必要であるため文言を統一しました。
* 同様にHTTPで利用するローカルポートも `8000` で統一しました。