### PR TITLE
3系ドキュメント：商品別税率設定が適用されない不具合についてのページが

### DIFF
--- a/pages/spec/tax.md
+++ b/pages/spec/tax.md
@@ -33,7 +33,8 @@ summary: EC-CUBEでは、税率の設定について、共通税率と商品ご�
 個別税率設定を有効にすると、商品単位（正確には商品規格単位）で税率が登録できるようになります。  
 
 <div style="background-color: #fdefef; margin: 2em 0 !important; padding: 1em;">
-**注意**
+<b>注意</b>
+</div>
 
 商品別税率が反映されない不具合が報告されています。   
 (EC-CUBE 3.0.0〜3.0.18までのバージョンが対象)   
@@ -44,16 +45,13 @@ summary: EC-CUBEでは、税率の設定について、共通税率と商品ご�
 修正ファイル：/src/Eccube/Repository/TaxRuleRepository.php   
 修正内容：[PullRequest #4310 の修正差分](https://github.com/EC-CUBE/ec-cube/pull/4310/files#diff-9ebf9d0c89cef624ee2648733e557603) をソースコードに反映
 
-</div>
-
 <div style="background-color: #fdefef; margin: 2em 0 !important; padding: 1em;">
-**注意**
+<b>注意</b>
+</div>
 
 共通税率と商品別税率の設定順序によっては、商品別税率が正しく反映されないケースが報告されています。
 
 詳細は [商品別税率設定が適用されない不具合について](/workaround-product-tax-rule) をご確認下さい。
-
-</div>
 
 ![個別税率を有効にする](/images/img-tax-03.png)  
 

--- a/pages/workaround-product-tax-rule.md
+++ b/pages/workaround-product-tax-rule.md
@@ -1,6 +1,8 @@
 ---
 title: 商品別税率設定が適用されない不具合について
+keywords: tax workaround 
 tags: [spec, getting_started]
+sidebar: home_sidebar
 permalink: workaround-product-tax-rule
 summary: 一定条件下で商品別税率設定が適用されない不具合の原因と対策。
 ---


### PR DESCRIPTION
### 1.
https://doc.ec-cube.net/workaround-product-tax-rule
が表示されないのを修正。

### 2.
税率設定の表示の崩れを修正。(divタグの中ではmarkdown表記使えなかった)