### PR TITLE
docker-composeを使って、 `docker-compose up -d` だけでビルド環境が立ち上がるようにしました。

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ EC-CUBE 4 の仕様や手順、開発Tipsに関するドキュメントを掲載
 修正や追記、新規ドキュメントの作成をいただく場合、本レポジトリへPullRequestをお送りください。
 
 
-### 開発協力に関して
+## 開発協力に関して
 
 コードの提供・追加、修正・変更その他「EC-CUBE」への開発の御協力（Issue投稿、PullRequest投稿など、GitHub上での活動）を行っていただく場合には、
 [EC-CUBEのコピーライトポリシー](https://github.com/EC-CUBE/ec-cube/wiki/EC-CUBE%E3%81%AE%E3%82%B3%E3%83%94%E3%83%BC%E3%83%A9%E3%82%A4%E3%83%88%E3%83%9D%E3%83%AA%E3%82%B7%E3%83%BC)をご理解いただき、ご了承いただく必要がございます。
@@ -14,13 +14,34 @@ PullRequestを送信する際は、EC-CUBEのコピーライトポリシーに�
 
 ## 本ドキュメントサイトの構成について
 
+### ツール
+
+**[Jekyll](http://jekyllrb-ja.github.io/)** を利用して *マークダウン形式のプレーンテキスト* から *HTML* を生成しています。
+
 github pageはJekyll Documentation themeを使っています。
 
-windows環境の方は以下のURLを参考に環境を作成してください。
-<a href="http://qiita.com/chihiro-adachi/items/99a82c902b4c8467aa4c" target="_blank">http://qiita.com/chihiro-adachi/items/99a82c902b4c8467aa4c</a>
+### 生成ドキュメントを確認するには
+
+Windows環境の方は以下のURLを参考に環境を作成してください。
+
+* [jekyll 2.5.3をWindows環境にインストール - Qiita](https://qiita.com/chihiro-adachi/items/99a82c902b4c8467aa4c){:target="_blank"}
+
+[Docker Compose](http://docs.docker.jp/compose/toc.html) がインストールされていればより簡単な方法でドキュメントを生成できます。  
+コマンドを実行後、 ブラウザで `http://localhost:4000` にアクセスしてください。
+
+```bash
+# ディレクトリ移動
+$ cd ec-cube.github.io
+
+# サーバ起動します。マークダウンファイルを編集すれば数秒後にHTMLの再生成が行われます。
+$ docker-compose up -d
+```
+
+---
 
 Build the site to see the instructions for using it. Or just go here: [http://idratherbewriting.com/documentation-theme-jekyll/](http://idratherbewriting.com/documentation-theme-jekyll/)
 
+---
 
 ## ローカル開発環境の構築
 

--- a/_config.yml
+++ b/_config.yml
@@ -104,6 +104,6 @@ description: "EC-CUBEのドキュメントサイトです。開発ガイドラ�
 # needed for sitemap.xml file only
 url: http://idratherbewriting.com
 
-google_analytics: UA-12978473-11
+google_analytics: UA-12978473-13
 
 repository: ec-cube/ec-cube.github.io

--- a/_config.yml
+++ b/_config.yml
@@ -105,3 +105,5 @@ description: "EC-CUBEのドキュメントサイトです。開発ガイドラ�
 url: http://idratherbewriting.com
 
 google_analytics: UA-12978473-11
+
+repository: ec-cube/ec-cube.github.io

--- a/_includes/google_analytics.html
+++ b/_includes/google_analytics.html
@@ -1,6 +1,12 @@
 <!-- the google_analytics_id gets auto inserted from the config file -->
-
 {% if site.google_analytics %}
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{site.google_analytics}}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-<script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');ga('create','{{site.google_analytics}}','auto');ga('require','displayfeatures');ga('send','pageview');</script>
+  gtag('config', '{{site.google_analytics}}');
+</script>
 {% endif %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "2"
+services:
+  jekyll:
+    image: bretfisher/jekyll-serve
+    command: [ "bundle", "exec", "jekyll", "serve", "--incremental", "--force_polling", "-H", "0.0.0.0", "-P", "4000" ]
+    volumes:
+      - .:/site
+    ports:
+      - '4000:4000'


### PR DESCRIPTION
1. `docker-compose up -d` でローカルドキュメント生成環境を構築できます。
2. 起動後は `http://localhost:4000` にアクセスしてください。
3. Markdown変更後は変更を自動的に検知しホットデプロイされます。